### PR TITLE
feat: add more trace via debug

### DIFF
--- a/private/Get-CommitChanges.ps1
+++ b/private/Get-CommitChanges.ps1
@@ -7,6 +7,8 @@ function Get-CommitChanges {
         [PSCustomObject] $Convention
     ) 
 
+    Write-Debug "Get-CommitChanges to summaries the commits changes."
+
     if (($CommitLog.BreakingChanges) -or ($CommitLog.ConventionalSubject.Breaking)) {
         $Changes.Breaking ++
     }

--- a/private/Get-CommitLogs.ps1
+++ b/private/Get-CommitLogs.ps1
@@ -9,6 +9,8 @@ function Get-CommitLogs {
 
     )
 
+    Write-Debug "Get-CommitLogs; from $From to: $To"
+
     $gitLogFormat = (@("%H", "%aI", "%s", "%b") -join ($LOG_FIELD_SEPARATOR)) + $LOG_COMMIT_DELIMITER;
 
     $gitLog = Invoke-Expression "git log --reverse --format=$gitLogFormat $($From)..$($To)"

--- a/private/Get-Config.ps1
+++ b/private/Get-Config.ps1
@@ -10,6 +10,8 @@ function Get-Config {
         $Path = Join-Path -Path $PSScriptRoot -ChildPath 'conventional-commit-default.json'
     }
 
+    Write-Debug "Getting conventional commit config file from: $Path"
+
     if (Test-Path -Path $Path) {
         $jsonFile = Get-Content -Raw $Path | ConvertFrom-Json
     }

--- a/private/Get-Version.ps1
+++ b/private/Get-Version.ps1
@@ -13,7 +13,11 @@ function Get-Version {
         "Patches"  = 0
     }
 
+    Write-Debug "Fetching the lastest release tag"
+
     $lastReleaseTag = Get-LastReleaseTag -CommitAnchor $commitAnchor
+
+    Write-Debug "Tag returned: $lastReleaseTag"
 
     if ($lastReleaseTag) {
         $lastVersionMatch = $lastReleaseTag -match '(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)'

--- a/private/Get-VersionBump.ps1
+++ b/private/Get-VersionBump.ps1
@@ -7,6 +7,8 @@ function Get-VersionBump {
 
     [version] $newVersion = $CurrentVersion
 
+    Write-Debug "Get-VersionBump; calculating the new version starting from $CurrentVersion"
+    
     # Don't change major when in development mode
     if ($currentVersion.Major -eq 0) {
         if (($Changes.Breaking -gt 0) -or ($Changes.Feature -gt 0)) {


### PR DESCRIPTION
Added trace to understand why it runs locally on Windows and as a standalone function on Linux, but when integrated with verizonconnect.cicd fails.