### PR TITLE
chore: change default version

### DIFF
--- a/private/Get-Version.ps1
+++ b/private/Get-Version.ps1
@@ -5,7 +5,7 @@ function Get-Version {
         [PSCustomObject] $Convention
     )
 
-    [version] $version = New-Object Version -ArgumentList 0, 1, 0
+    [version] $version = New-Object Version -ArgumentList 0, 0, 1
 
     $changes = @{
         "Breaking" = 0


### PR DESCRIPTION
Having the default version of 0.1.0 is troublesome given that 0.0.1 is a valid version and having the default version returned as 0.1.0 removes the option to use any version below that.