### PR TITLE
fix: Allow support for a 2 digit version.

### DIFF
--- a/private/Get-Version.ps1
+++ b/private/Get-Version.ps1
@@ -20,13 +20,13 @@ function Get-Version {
     Write-Debug "Tag returned: $lastReleaseTag"
 
     if ($lastReleaseTag) {
-        $lastVersionMatch = $lastReleaseTag -match '(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)'
+        $lastVersionMatch = $lastReleaseTag -match '(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+))?'
 
         if (-not $lastVersionMatch) {
             throw "Couldn't find the semantic version from the last release tag $lastReleaseTag"
         }
 
-        $version = New-Object Version -ArgumentList $Matches.major, (IIf $Matches.minor $Matches.minor "0"), (IIf $Matches.patch $Matches.patch "0")
+        $version = New-Object Version -ArgumentList $Matches.major, $Matches.minor, $Matches.patch
 
         $commitLogs = Get-CommitLogs -From $lastReleaseTag -To $CommitAnchor
 


### PR DESCRIPTION
The module should allow 2 digit tags, as we will substitute a invalid patch to be zero,
The minimum supported is a 2 digit version, anything else will throw an error.